### PR TITLE
12 Add pagination to GET routes

### DIFF
--- a/AzurLaneAPI.API/Controllers/V1/ShipsController.cs
+++ b/AzurLaneAPI.API/Controllers/V1/ShipsController.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using AzurLaneAPI.Domain.APIQueryParameters;
 using AzurLaneAPI.Domain.Data;
 using AzurLaneAPI.Domain.Dtos.Ship;
 using AzurLaneAPI.Domain.Entities;
@@ -28,8 +29,8 @@ public class ShipsController : V1BaseController
 
 	[AllowAnonymous]
 	[HttpGet(Routes.V1.Ships.GetAll)]
-	public async Task<ActionResult<IEnumerable<ShipDto>>> GetAll() =>
-		Ok(Mapper.Map<IEnumerable<ShipDto>>(await _shipRepository.GetAsync()));
+	public async Task<ActionResult<IEnumerable<ShipDto>>> GetAll([FromQuery] PaginationParameters pageParams) =>
+		Ok(Mapper.Map<IEnumerable<ShipDto>>(await _shipRepository.GetAsync(pageParams)));
 
 	[AllowAnonymous]
 	[HttpGet(Routes.V1.Ships.GetSingleById)]
@@ -53,8 +54,9 @@ public class ShipsController : V1BaseController
 
 	[AllowAnonymous]
 	[HttpGet(Routes.V1.Ships.Minimal)]
-	public async Task<ActionResult<IEnumerable<MinimalShipDataDto>>> GetMinimalShips() =>
-		Ok(await _shipRepository.GetMinimalAsync());
+	public async Task<ActionResult<IEnumerable<MinimalShipDataDto>>> GetMinimalShips(
+		[FromQuery] PaginationParameters pageParams) =>
+		Ok(await _shipRepository.GetMinimalAsync(pageParams));
 
 	[Authorize(Policy = IdentityNames.Policies.RequireContributorRole)]
 	[HttpPost(Routes.V1.Ships.Create)]

--- a/AzurLaneAPI.Domain/APIQueryParameters/PaginationParameters.cs
+++ b/AzurLaneAPI.Domain/APIQueryParameters/PaginationParameters.cs
@@ -1,0 +1,13 @@
+﻿namespace AzurLaneAPI.Domain.APIQueryParameters;
+
+public sealed class PaginationParameters
+{
+	public int PageNumber { get; set; } = 1;
+	public int PageSize { get; set; } = 10;
+	
+	public PaginationParameters()
+	{
+		PageNumber = 1;
+		PageSize = 10;
+	}
+}

--- a/AzurLaneAPI.Domain/Repositories/IShipRepository.cs
+++ b/AzurLaneAPI.Domain/Repositories/IShipRepository.cs
@@ -1,5 +1,7 @@
-﻿using AzurLaneAPI.Domain.Dtos.Ship;
+﻿using AzurLaneAPI.Domain.APIQueryParameters;
+using AzurLaneAPI.Domain.Dtos.Ship;
 using AzurLaneAPI.Domain.Entities;
+using Microsoft.Extensions.Primitives;
 
 namespace AzurLaneAPI.Domain.Repositories;
 
@@ -7,5 +9,6 @@ public interface IShipRepository : IRepository<Ship, string>
 {
 	public Task<bool> ExistsWithNameAsync(string name);
 	public Task<Ship> GetByNameAsync(string name);
-	public Task<IEnumerable<MinimalShipDataDto>> GetMinimalAsync();
+	public Task<IEnumerable<MinimalShipDataDto>> GetMinimalAsync(PaginationParameters parameters);
+	public Task<IEnumerable<Ship>> GetAsync(PaginationParameters parameters);
 }

--- a/AzurLaneAPI.Domain/Repositories/ShipRepository.cs
+++ b/AzurLaneAPI.Domain/Repositories/ShipRepository.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using AzurLaneAPI.Domain.APIQueryParameters;
 using AzurLaneAPI.Domain.Data;
 using AzurLaneAPI.Domain.Dtos.Ship;
 using AzurLaneAPI.Domain.Entities;
@@ -60,7 +61,23 @@ public class ShipRepository : Repository<Ship, string>, IShipRepository
 			.FirstAsync(x => x.EnglishName == name || x.JapaneseName == name || x.ChineseName == name);
 	}
 
-	public async Task<IEnumerable<MinimalShipDataDto>> GetMinimalAsync() =>
-		await _mapper.ProjectTo<MinimalShipDataDto>(Context.Ships)
+	public async Task<IEnumerable<MinimalShipDataDto>> GetMinimalAsync(PaginationParameters parameters) =>
+		await _mapper.ProjectTo<MinimalShipDataDto>(Context.Ships
+			.Skip((parameters.PageNumber - 1) * parameters.PageSize)
+			.Take(parameters.PageSize)).ToListAsync();
+
+	public async Task<IEnumerable<Ship>> GetAsync(PaginationParameters parameters)
+	{
+		return await Context.Ships
+			.Include(x => x.Faction)
+			.Include(x => x.BaseStats)
+			.Include(x => x.Level100Stats)
+			.Include(x => x.Level120Stats)
+			.Include(x => x.Level125Stats)
+			.Include(x => x.Type)
+			.Include(x => x.Subclass)
+			.Skip((parameters.PageNumber - 1) * parameters.PageSize)
+			.Take(parameters.PageSize)
 			.ToListAsync();
+	}
 }


### PR DESCRIPTION
Currently applied to `/ships` and `/ships/minimal`

Currently no pagination response headers that indicate pages